### PR TITLE
Fixing #7

### DIFF
--- a/src/Nancy.BootStrappers.Windsor.Tests/ApplicationRegistrationTask.cs
+++ b/src/Nancy.BootStrappers.Windsor.Tests/ApplicationRegistrationTask.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Nancy.Bootstrapper;
+
+namespace Nancy.Bootstrappers.Windsor.Tests
+{
+    //public class ApplicationRegistrationTask : IApplicationRegistrations
+    //{
+    //    public IEnumerable<TypeRegistration> TypeRegistrations
+    //    {
+    //        get { return new[]
+    //                     {
+    //                         new TypeRegistration(typeof(IType1), typeof(Type)),
+    //                         new TypeRegistration(typeof(IType2), typeof(Type))
+    //                     }; }
+    //    }
+
+    //    public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations
+    //    {
+    //        get { return null; }
+    //    }
+
+    //    public IEnumerable<InstanceRegistration> InstanceRegistrations
+    //    {
+    //        get { return null; }
+    //    }
+
+    //    public interface IType1 {}
+    //    public interface IType2 {}
+    //    public class Type : IType1, IType2 {}
+    //}
+}

--- a/src/Nancy.BootStrappers.Windsor.Tests/ApplicationRegistrationTask.cs
+++ b/src/Nancy.BootStrappers.Windsor.Tests/ApplicationRegistrationTask.cs
@@ -3,29 +3,32 @@ using Nancy.Bootstrapper;
 
 namespace Nancy.Bootstrappers.Windsor.Tests
 {
-    //public class ApplicationRegistrationTask : IApplicationRegistrations
-    //{
-    //    public IEnumerable<TypeRegistration> TypeRegistrations
-    //    {
-    //        get { return new[]
-    //                     {
-    //                         new TypeRegistration(typeof(IType1), typeof(Type)),
-    //                         new TypeRegistration(typeof(IType2), typeof(Type))
-    //                     }; }
-    //    }
+    public class ApplicationRegistrationTask : IApplicationRegistrations
+    {
+        public IEnumerable<TypeRegistration> TypeRegistrations
+        {
+            get
+            {
+                return new[]
+                         {
+                             new TypeRegistration(typeof(IType1), typeof(Type)),
+                             new TypeRegistration(typeof(IType2), typeof(Type))
+                         };
+            }
+        }
 
-    //    public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations
-    //    {
-    //        get { return null; }
-    //    }
+        public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations
+        {
+            get { return null; }
+        }
 
-    //    public IEnumerable<InstanceRegistration> InstanceRegistrations
-    //    {
-    //        get { return null; }
-    //    }
+        public IEnumerable<InstanceRegistration> InstanceRegistrations
+        {
+            get { return null; }
+        }
 
-    //    public interface IType1 {}
-    //    public interface IType2 {}
-    //    public class Type : IType1, IType2 {}
-    //}
+        public interface IType1 { }
+        public interface IType2 { }
+        public class Type : IType1, IType2 { }
+    }
 }

--- a/src/Nancy.BootStrappers.Windsor.Tests/ApplicationRegistrationTask.cs
+++ b/src/Nancy.BootStrappers.Windsor.Tests/ApplicationRegistrationTask.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using Nancy.Bootstrapper;
-
 namespace Nancy.Bootstrappers.Windsor.Tests
 {
+    using System.Collections.Generic;
+    using Bootstrapper;
+
     public class ApplicationRegistrationTask : IApplicationRegistrations
     {
         public IEnumerable<TypeRegistration> TypeRegistrations

--- a/src/Nancy.BootStrappers.Windsor.Tests/Nancy.BootStrappers.Windsor.Tests.csproj
+++ b/src/Nancy.BootStrappers.Windsor.Tests/Nancy.BootStrappers.Windsor.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="..\..\dependencies\Nancy\src\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ApplicationRegistrationTask.cs" />
     <Compile Include="BoostrapperBaseFixture.cs" />
     <Compile Include="Fakes\FakeNancyModuleWithBasePath.cs" />
     <Compile Include="Fakes\FakeNancyModuleWithDependency.cs" />

--- a/src/Nancy.BootStrappers.Windsor.Tests/WindsorNancyBootStrapperFixture.cs
+++ b/src/Nancy.BootStrappers.Windsor.Tests/WindsorNancyBootStrapperFixture.cs
@@ -97,7 +97,7 @@ namespace Nancy.Bootstrappers.Windsor.Tests
 
             // Then
             this.bootstrapper.Container.Resolve<INancyEngine>()
-                .GetType().Name.ShouldEqual("INancyEngineProxy");
+                .GetType().Name.ShouldEqual("NancyEngineProxy");
         }
 
         [Fact]
@@ -144,8 +144,8 @@ namespace Nancy.Bootstrappers.Windsor.Tests
             response1.ShouldNotEqual(response2);
             ctx1.Dispose();
             ctx2.Dispose();
-        }
-
+        }        
+        
         [Fact(Skip = "For testing memory leaks only")]
         public void Check_windsor_memory_leak()
         { 

--- a/src/Nancy.BootStrappers.Windsor/WindsorNancyBootstrapper.cs
+++ b/src/Nancy.BootStrappers.Windsor/WindsorNancyBootstrapper.cs
@@ -1,5 +1,3 @@
-using Castle.Facilities.TypedFactory;
-
 namespace Nancy.Bootstrappers.Windsor
 {
     using System;
@@ -9,9 +7,10 @@ namespace Nancy.Bootstrappers.Windsor
     using Castle.MicroKernel.Lifestyle.Scoped;
     using Castle.MicroKernel.Registration;
     using Castle.MicroKernel.Resolvers.SpecializedResolvers;
+    using Castle.Facilities.TypedFactory;
     using Castle.Windsor;
     using Diagnostics;
-    using Nancy.Bootstrapper;
+    using Bootstrapper;
 
     /// <summary>
     /// Nancy bootstrapper for the Windsor container.
@@ -205,18 +204,6 @@ namespace Nancy.Bootstrappers.Windsor
             }
         }
 
-        static void RegisterNewOrAddService(IWindsorContainer container, Type registrationType, Type implementationType)
-        {
-            var handler = container.Kernel.GetHandler(implementationType);
-            if (handler != null)
-            {
-                handler.ComponentModel.AddService(registrationType);
-                return;
-            }
-
-            container.Register(Component.For(implementationType, registrationType).ImplementedBy(implementationType));
-        }
-
         /// <summary>
         /// Register the given instances into the container
         /// </summary>
@@ -229,6 +216,18 @@ namespace Nancy.Bootstrappers.Windsor
                 container.Register(Component.For(instanceRegistration.RegistrationType)
                     .Instance(instanceRegistration.Implementation));
             }
+        }
+
+        private static void RegisterNewOrAddService(IWindsorContainer container, Type registrationType, Type implementationType)
+        {
+            var handler = container.Kernel.GetHandler(implementationType);
+            if (handler != null)
+            {
+                handler.ComponentModel.AddService(registrationType);
+                return;
+            }
+
+            container.Register(Component.For(implementationType, registrationType).ImplementedBy(implementationType));
         }
     }
 }


### PR DESCRIPTION
I've changed the bootstrapper to be independent on the number and/or order of calls to RegisterTypes and RegisterCollectionTypes. 

The need for this is shown by adding an ApplicationRegistrationTask that will be picked up by Initialize() which in turn calls RegisterTypes twice. The old implementation threw.

It's somewhat hacky to change the ComponentModels directly, but at least contained.

For some reason the name of the proxy for INancyEngine changed with this new implementation. It still proxies as it should, so it seems ok?
