### PR TITLE
Extracted the configuration of the container

### DIFF
--- a/src/Nancy.BootStrappers.Windsor/WindsorNancyBootstrapper.cs
+++ b/src/Nancy.BootStrappers.Windsor/WindsorNancyBootstrapper.cs
@@ -62,13 +62,22 @@ namespace Nancy.Bootstrappers.Windsor
 
             var container = new WindsorContainer();
 
+            ConfigureContainer(container);
+
+            return container;
+        }
+
+        /// <summary>
+        /// Configures all necessary dependencies for Nancy
+        /// </summary>
+        /// <param name="container">Container instance</param>
+        protected void ConfigureContainer(IWindsorContainer container)
+        {
             container.AddFacility<TypedFactoryFacility>();
             container.Kernel.Resolver.AddSubResolver(new CollectionResolver(container.Kernel, true));
             container.Register(Component.For<IWindsorContainer>().Instance(container));
             container.Register(Component.For<NancyRequestScopeInterceptor>());
             container.Kernel.ProxyFactory.AddInterceptorSelector(new NancyRequestScopeInterceptorSelector());
-
-            return container;
         }
 
         /// <summary>


### PR DESCRIPTION
Hey there,

I've extracted the configuration of the container so that it could be also used with an existing container instance.

I often have the need to have the container registered before I could pass it to Nancy. At the moment I have to do the configuration of Castle by myself, which means that I have to take care of possible changes in Nancy. As the Windsor bootstraper already has the knowledge it should provide its knowledge for configuration of an existing container.

Thoughts?
