### PR TITLE
Container incorrectly configured when providing external container via GetApplicationContainer override.

### DIFF
--- a/src/Nancy.BootStrappers.Windsor/WindsorNancyBootstrapper.cs
+++ b/src/Nancy.BootStrappers.Windsor/WindsorNancyBootstrapper.cs
@@ -64,14 +64,29 @@ namespace Nancy.Bootstrappers.Windsor
             }
 
             var container = new WindsorContainer();
-
-            container.AddFacility<TypedFactoryFacility>();
-            container.Kernel.Resolver.AddSubResolver(new CollectionResolver(container.Kernel, true));
-            container.Register(Component.For<IWindsorContainer>().Instance(container));
-            container.Register(Component.For<NancyRequestScopeInterceptor>());
-            container.Kernel.ProxyFactory.AddInterceptorSelector(new NancyRequestScopeInterceptorSelector());
-
             return container;
+        }
+
+        /// <summary>
+        /// Configures the container for use with Nancy.
+        /// </summary>
+        /// <param name="existingContainer">
+        /// An existing container.
+        /// </param>
+        protected override void ConfigureApplicationContainer(IWindsorContainer existingContainer)
+        {
+            var factoryType = typeof(TypedFactoryFacility);
+            if (!existingContainer.Kernel.GetFacilities()
+                .Any(x => x.GetType() == factoryType))
+            {
+                existingContainer.AddFacility<TypedFactoryFacility>();
+            }
+            existingContainer.Kernel.Resolver.AddSubResolver(new CollectionResolver(existingContainer.Kernel, true));
+            existingContainer.Register(Component.For<IWindsorContainer>().Instance(existingContainer));
+            existingContainer.Register(Component.For<NancyRequestScopeInterceptor>());
+            existingContainer.Kernel.ProxyFactory.AddInterceptorSelector(new NancyRequestScopeInterceptorSelector());
+
+            base.ConfigureApplicationContainer(existingContainer);
         }
 
         /// <summary>


### PR DESCRIPTION
When overriding `GetApplicationContainer` in a subclass of `WindsorNancyBootstrapper` and returning an existing `IWindsorContainer` that is not created by the `WindsorNancyBootstrapper`, the container is not configured correctly for use with Nancy, resulting in the exception `Castle.MicroKernel.Handlers.HandlerException: Handler for System.Collections.Generic.IEnumerable`1[Nancy.ViewEngines.IViewEngine] was not found.`

Workarounds provided [here](http://www.rscampos.net/post/2012/03/26/Nancy-2.aspx) and [here](http://sixgun.wordpress.com/2014/05/30/nancyfx-castle-windsor/) copy the registration of the components verbatim from `WindsorNancyBootstrapper`. I would like to suggest that the configuration of the container occurs in an override of `ConfigureApplicationContainer(IWindsorContainer existingContainer)` so that both containers owned by `WindsorNancyBootstrapper` and provided to it will result in correctly configured containers. If configuration is not required it will be possible to opt out of the registration via subclass of `WindsorNancyBootstrapper` and override of `ConfigureApplicationContainer`.

Happy to submit a pull request for the change.
