### PR TITLE
Massive clean up build.cake

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -7,7 +7,10 @@ using System.Xml.XPath;
 var target = Argument<string>("target", "Default");
 var source = Argument<string>("source", null);
 var apiKey = Argument<string>("apikey", null);
-var version = target.ToLower() == "default" ? "2.0.0-Pre" + (EnvironmentVariable("APPVEYOR_BUILD_NUMBER") ?? "0") : GetNancyVersion(new FilePath("dependencies/Nancy/src/Nancy/project.json"));
+
+var version = target.ToLower() == "default"
+    ? "2.0.0-Pre" + (EnvironmentVariable("APPVEYOR_BUILD_NUMBER") ?? "0")
+    : GetNancyVersion(new FilePath("dependencies/Nancy/src/Nancy/project.json"));
 
 // Variables
 var configuration = IsRunningOnWindows() ? "Release" : "MonoRelease";
@@ -19,209 +22,234 @@ var outputBinariesNet452 = outputBinaries + Directory("net452");
 var outputBinariesNetstandard = outputBinaries + Directory("netstandard1.6");
 var outputPackages = output + Directory("packages");
 var outputNuGet = output + Directory("nuget");
-var xunit = "test/Nancy.Bootstrappers.Windsor.Tests/bin/"+configuration+"/net452/unix-x64/dotnet-test-xunit.exe";
+var xunit = "test/Nancy.Bootstrappers.Windsor.Tests/bin/" + configuration + "/net452/unix-x64/dotnet-test-xunit.exe";
 
-///////////////////////////////////////////////////////////////
-
-Task("Clean")
-  .Does(() =>
-{
-  // Clean artifact directories.
-  CleanDirectories(new DirectoryPath[] {
-    output, outputBinaries, outputPackages, outputNuGet,
-    outputBinariesNet452, outputBinariesNetstandard
-  });
-
-  // Clean output directories.
-  CleanDirectories("./src/**/" + configuration);
-  CleanDirectories("./test/**/" + configuration);
-});
-
-Task("Update-Version")
-  .Description("Update version")
-  .Does(() =>
-{
-  Information("Setting version to " + version);
-  if(string.IsNullOrWhiteSpace(version)) {
-    throw new CakeException("No version specified!");
-  }
-  var file = new FilePath("src/Nancy.Bootstrappers.Windsor/project.json");
-
-  var project = System.IO.File.ReadAllText(file.FullPath, Encoding.UTF8);
-
-  project = System.Text.RegularExpressions.Regex.Replace(project, "(\"version\":\\s*)\".+\"", "$1\"" + version + "\"");
-
-  System.IO.File.WriteAllText(file.FullPath, project, Encoding.UTF8);
-});
-
-
-Task("Restore-NuGet-Packages")
-  .Description("Restores NuGet packages")
-  .Does(() =>
-  {
-    var settings = new DotNetCoreRestoreSettings
-    {
-      Verbose = false,
-      Verbosity = DotNetCoreRestoreVerbosity.Warning,
-      Sources = new [] {
-          "https://www.myget.org/F/xunit/api/v3/index.json",
-          "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json",
-          "https://dotnet.myget.org/F/cli-deps/api/v3/index.json",
-          "https://api.nuget.org/v3/index.json",
-       }
-    };
-
-  //Restore at root until preview1-002702 bug fixed
-  DotNetCoreRestore("./", settings);
-  //DotNetCoreRestore("./src", settings);
-  //DotNetCoreRestore("./test", settings);
-});
-
-Task("Compile")
-  .Description("Builds the solution")
-  .IsDependentOn("Clean")
-  .IsDependentOn("Update-Version")
-  .IsDependentOn("Restore-NuGet-Packages")
-  .Does(() =>
-{
-  var projects = GetFiles("./src/**/*.xproj") + GetFiles("./test/**/*.xproj");
-  foreach(var project in projects)
-  {
-      DotNetCoreBuild(project.GetDirectory().FullPath, new DotNetCoreBuildSettings {
-        Configuration = configuration,
-        Verbose = false,
-        Runtime = IsRunningOnWindows() ? null : "unix-x64"
-      });
-  }
-});
-
-Task("Test")
-  .Description("Executes xUnit tests")
-  .IsDependentOn("Compile")
-  .Does(() =>
-{
-  if (IsRunningOnWindows())
-  {
-    var projects = GetFiles("./test/**/*.xproj");
-
-    foreach(var project in projects)
-    {
-      DotNetCoreTest(project.GetDirectory().FullPath, new DotNetCoreTestSettings {
-        Configuration = configuration
-      });
-    }
-  }
-  else
-  {
-    // For when test projects are set to run against netstandard
-
-    // DotNetCoreTest(project.GetDirectory().FullPath, new DotNetCoreTestSettings {
-    //   Configuration = configuration,
-    //   Framework = "netstandard1.6",
-    //   Runtime = "unix-64"
-    // });
-
-    using(var process = StartAndReturnProcess("mono", new ProcessSettings{Arguments =
-      xunit + " " +
-      "test/Nancy.Bootstrappers.Windsor.Tests/bin/"+configuration+"/net452/unix-x64/Nancy.Bootstrappers.Windsor.Tests.dll"}))
-    {
-      process.WaitForExit();
-      if(process.GetExitCode() != 0)
-      {
-        throw new Exception("Nancy.Bootstrappers.Windsor.Tests failed");
-      }
-    }
-  }
-});
-
-Task("Publish")
-  .Description("Gathers output files and copies them to the output folder")
-  .IsDependentOn("Compile")
-  .Does(() =>
-{
-  // Copy net452 binaries.
-  CopyFiles(GetFiles("src/**/bin/" + configuration + "/net452/*.dll")
-    + GetFiles("src/**/bin/" + configuration + "/net452/*.xml")
-    + GetFiles("src/**/bin/" + configuration + "/net452/*.pdb")
-    + GetFiles("src/**/*.ps1"), outputBinariesNet452);
-
-  // Copy netstandard binaries.
-  CopyFiles(GetFiles("src/**/bin/" + configuration + "/netstandard1.6/*.dll")
-    + GetFiles("src/**/bin/" + configuration + "/netstandard1.6/*.xml")
-    + GetFiles("src/**/bin/" + configuration + "/netstandard1.6/*.pdb")
-    + GetFiles("src/**/*.ps1"), outputBinariesNetstandard);
-
-});
-
-Task("Package")
-  .Description("Zips up the built binaries for easy distribution")
-  .IsDependentOn("Publish")
-  .Does(() =>
-{
-  var package = outputPackages + File("Nancy.Bootstrappers.Windsor-Latest.zip");
-  var files = GetFiles(outputBinaries.Path.FullPath + "/**/*");
-
-  Zip(outputBinaries, package, files);
-});
-
-Task("Nuke-Symbol-Packages")
-  .Description("Deletes symbol packages")
-  .Does(() =>
-{
-  DeleteFiles(GetFiles("./**/*.Symbols.nupkg"));
-});
-
-Task("Package-NuGet")
-  .Description("Generates NuGet packages for each project that contains a nuspec")
-  .Does(() =>
-{
-  var projects = GetFiles("src/**/*.xproj");
-  foreach(var project in projects)
-  {
-    var settings = new DotNetCorePackSettings {
-      Configuration = "Release",
-      OutputDirectory = outputNuGet
-    };
-
-    DotNetCorePack(project.GetDirectory().FullPath, settings);
-  }
-});
-
-Task("Publish-NuGet")
-  .Description("Pushes the nuget packages in the nuget folder to a NuGet source. Also publishes the packages into the feeds.")
-  .Does(() =>
-{
-  // Make sure we have an API key.
-  if(string.IsNullOrWhiteSpace(apiKey)){
-    throw new CakeException("No NuGet API key provided.");
-  }
-
-  // Upload every package to the provided NuGet source (defaults to nuget.org).
-  var packages = GetFiles(outputNuGet.Path.FullPath + "/*" + version + ".nupkg");
-  foreach(var package in packages)
-  {
-    NuGetPush(package, new NuGetPushSettings {
-      Source = source,
-      ApiKey = apiKey
-    });
-  }
-});
-
-///////////////////////////////////////////////////////////////
-
-public string GetNancyVersion(FilePath filePath)
-{
-  var project = System.IO.File.ReadAllText(filePath.FullPath, Encoding.UTF8);
-  return System.Text.RegularExpressions.Regex.Match(project, "\"version\":\\s*\"(.+)\"").Groups[1].ToString();
-}
+/*
+/ TASK DEFINITIONS
+*/
 
 Task("Default")
-  .IsDependentOn("Test")
-  .IsDependentOn("Package-NuGet");
+    .IsDependentOn("Test")
+    .IsDependentOn("Package-NuGet");
 
-Task("Mono")
-  .IsDependentOn("Test");
+Task("Clean")
+    .Does(() =>
+    {
+        // Clean artifact directories.
+        CleanDirectories(new DirectoryPath[] {
+            output,
+            outputBinaries,
+            outputPackages,
+            outputNuGet,
+            outputBinariesNet452,
+            outputBinariesNetstandard
+        });
 
-///////////////////////////////////////////////////////////////
+        // Clean output directories.
+        CleanDirectories("./src/**/" + configuration);
+        CleanDirectories("./test/**/" + configuration);
+    });
+
+Task("Compile")
+    .Description("Builds the solution")
+    .IsDependentOn("Clean")
+    .IsDependentOn("Update-Version")
+    .IsDependentOn("Restore-NuGet-Packages")
+    .Does(() =>
+    {
+        var projects =
+            GetFiles("./src/**/*.xproj") +
+            GetFiles("./test/**/*.xproj");
+
+        foreach(var project in projects)
+        {
+            DotNetCoreBuild(project.GetDirectory().FullPath, new DotNetCoreBuildSettings {
+                Configuration = configuration,
+                Verbose = false,
+                Runtime = IsRunningOnWindows() ? null : "unix-x64"
+            });
+        }
+    });
+
+Task("Package")
+    .Description("Zips up the built binaries for easy distribution")
+    .IsDependentOn("Publish")
+    .Does(() =>
+    {
+        var package =
+            outputPackages + File("Nancy.Bootstrappers.Windsor-Latest.zip");
+
+        var files =
+            GetFiles(outputBinaries.Path.FullPath + "/**/*");
+
+        Zip(outputBinaries, package, files);
+    });
+
+Task("Package-NuGet")
+    .Description("Generates NuGet packages for each project that contains a nuspec")
+    .Does(() =>
+    {
+        var projects =
+            GetFiles("src/**/*.xproj");
+
+        foreach(var project in projects)
+        {
+            var settings = new DotNetCorePackSettings {
+                Configuration = "Release",
+                OutputDirectory = outputNuGet
+            };
+
+            DotNetCorePack(project.GetDirectory().FullPath, settings);
+        }
+    });
+
+Task("Publish")
+    .Description("Gathers output files and copies them to the output folder")
+    .IsDependentOn("Compile")
+    .Does(() =>
+    {
+        // Copy net452 binaries.
+        CopyFiles(GetFiles("src/**/bin/" + configuration + "/net452/*.dll")
+            + GetFiles("src/**/bin/" + configuration + "/net452/*.xml")
+            + GetFiles("src/**/bin/" + configuration + "/net452/*.pdb")
+            + GetFiles("src/**/*.ps1"), outputBinariesNet452);
+
+        // Copy netstandard binaries.
+        CopyFiles(GetFiles("src/**/bin/" + configuration + "/netstandard1.6/*.dll")
+            + GetFiles("src/**/bin/" + configuration + "/netstandard1.6/*.xml")
+            + GetFiles("src/**/bin/" + configuration + "/netstandard1.6/*.pdb")
+            + GetFiles("src/**/*.ps1"), outputBinariesNetstandard);
+    });
+
+Task("Publish-NuGet")
+    .Description("Pushes the nuget packages in the nuget folder to a NuGet source. Also publishes the packages into the feeds.")
+    .Does(() =>
+    {
+        if(string.IsNullOrWhiteSpace(apiKey)){
+            throw new CakeException("No NuGet API key provided. You need to pass in --apikey=\"xyz\"");
+        }
+
+        var packages =
+            GetFiles(outputNuGet.Path.FullPath + "/*.nupkg") -
+            GetFiles(outputNuGet.Path.FullPath + "/*.symbols.nupkg");
+
+        foreach(var package in packages)
+        {
+            NuGetPush(package, new NuGetPushSettings {
+                Source = source,
+                ApiKey = apiKey
+            });
+        }
+    });
+
+Task("Restore-NuGet-Packages")
+    .Description("Restores NuGet packages")
+    .Does(() =>
+    {
+        var settings = new DotNetCoreRestoreSettings
+        {
+            Verbose = false,
+            Verbosity = DotNetCoreRestoreVerbosity.Warning,
+            Sources = new [] {
+                "https://www.myget.org/F/xunit/api/v3/index.json",
+                "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json",
+                "https://dotnet.myget.org/F/cli-deps/api/v3/index.json",
+                "https://api.nuget.org/v3/index.json",
+            }
+        };
+
+        //Restore at root until preview1-002702 bug fixed
+        DotNetCoreRestore("./", settings);
+        //DotNetCoreRestore("./src", settings);
+        //DotNetCoreRestore("./test", settings);
+    });
+
+Task("Test")
+    .Description("Executes unit tests")
+    .IsDependentOn("Compile")
+    .Does(() =>
+    {
+        if (IsRunningOnWindows())
+        {
+            var projects =
+                GetFiles("./test/**/*.xproj");
+
+            foreach(var project in projects)
+            {
+                DotNetCoreTest(project.GetDirectory().FullPath, new DotNetCoreTestSettings {
+                    Configuration = configuration
+                });
+            }
+        }
+        else
+        {
+            // For when test projects are set to run against netstandard
+
+            // DotNetCoreTest(project.GetDirectory().FullPath, new DotNetCoreTestSettings {
+            //   Configuration = configuration,
+            //   Framework = "netstandard1.6",
+            //   Runtime = "unix-64"
+            // });
+
+            var settings = new ProcessSettings {
+                Arguments = xunit + " " + "test/Nancy.Bootstrappers.Windsor.Tests/bin/"+configuration+"/net452/unix-x64/Nancy.Bootstrappers.Windsor.Tests.dll"
+            };
+
+            using(var process = StartAndReturnProcess("mono", settings))
+            {
+                process.WaitForExit();
+                if(process.GetExitCode() != 0)
+                {
+                    throw new Exception("Nancy.Bootstrappers.Windsor.Tests failed.");
+                }
+            }
+        }
+    });
+
+Task("Update-Version")
+    .Description("Update version")
+    .Does(() =>
+    {
+        Information("Setting version to " + version);
+
+        if(string.IsNullOrWhiteSpace(version)) {
+            throw new CakeException("No version specified! You need to pass in --targetversion=\"x.y.z\"");
+        }
+
+        UpdateProjectJsonVersion(version, "src/Nancy.Bootstrappers.Windsor/project.json");
+    });
+
+/*
+/ RUN BUILD TARGET
+*/
 
 RunTarget(target);
+
+/*
+/ HELPER FUNCTIONS
+*/
+
+public static string GetNancyVersion(FilePath filePath)
+{
+    var project =
+        System.IO.File.ReadAllText(filePath.FullPath, Encoding.UTF8);
+
+    return System.Text.RegularExpressions.Regex.Match(project, "\"version\":\\s*\"(.+)\"").Groups[1].ToString();
+}
+
+public static void UpdateProjectJsonVersion(string version, string path)
+{
+    var file =
+        new FilePath(path);
+
+    var project =
+        System.IO.File.ReadAllText(file.FullPath, Encoding.UTF8);
+
+    var projectVersion =
+        new System.Text.RegularExpressions.Regex("(\"version\":\\s*)\".+\"");
+
+    project =
+        projectVersion.Replace(project, "$1\"" + version + "\"", 1);
+
+    System.IO.File.WriteAllText(file.FullPath, project, Encoding.UTF8);
+}


### PR DESCRIPTION
- Sorted all tasks in alphabetical order (this was driving me nuts, kept scrolling around to find the right ones)
- Fixed the indentation in the entire file
- General formatting changes to make it conform with our usual coding guidelines
- Updated `Publish-NuGet` task to filter out `*.symbols.nupkg` files
- Removed `Nuke-Symbol-Packages` (nothing was calling it)
- Removed `Mono` task (nothing was calling it, not even from `build.ps1/sh`)
- Added section dividers between helper functions, tasks etc
- Moved helper functions to the bottom of the file and make them static
- Updated `UpdateProjectJsonVersion` function so it only updates the first `version`-attribute

I have executed all the tasks locally on my machine to make sure they work and do not throw any errors.